### PR TITLE
fix: resolve clippy warnings and add serde-support feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,11 @@ net_http = ["dep:reqwest", "dep:tokio"]
 terminal-ui = ["dep:ratatui", "dep:crossterm"]
 observability = ["metrics", "dep:opentelemetry"]
 k8s = ["dep:kube", "dep:k8s-openapi", "dep:tokio"]
-mcp = ["dep:serde", "dep:serde_json"]
+mcp = ["dep:serde", "dep:serde_json", "serde-support"]
 sigilforge = ["dep:sigilforge-client", "dep:tokio"]
+
+# Serde support for JSON encoding/decoding
+serde-support = ["dep:serde", "dep:serde_json"]
 
 # Safety controls
 sandbox = []

--- a/src/format.rs
+++ b/src/format.rs
@@ -60,24 +60,22 @@ pub fn json_encode(args: &[Value], _ctx: &ExecutionContext) -> fusabi_host::Resu
 }
 
 /// Decode a JSON string to a value.
+#[cfg(feature = "serde-support")]
 pub fn json_decode(args: &[Value], _ctx: &ExecutionContext) -> fusabi_host::Result<Value> {
     let json_str = args.first().and_then(|v| v.as_str()).ok_or_else(|| {
         fusabi_host::Error::host_function("format.json_decode: missing JSON string")
     })?;
 
-    #[cfg(feature = "serde-support")]
-    {
-        Value::from_json_str(json_str)
-            .map_err(|e| fusabi_host::Error::host_function(format!("format.json_decode: {}", e)))
-    }
+    Value::from_json_str(json_str)
+        .map_err(|e| fusabi_host::Error::host_function(format!("format.json_decode: {}", e)))
+}
 
-    #[cfg(not(feature = "serde-support"))]
-    {
-        // Simple parsing without serde (very limited)
-        Err(fusabi_host::Error::host_function(
-            "json_decode requires serde-support feature",
-        ))
-    }
+/// Decode a JSON string to a value.
+#[cfg(not(feature = "serde-support"))]
+pub fn json_decode(_args: &[Value], _ctx: &ExecutionContext) -> fusabi_host::Result<Value> {
+    Err(fusabi_host::Error::host_function(
+        "json_decode requires serde-support feature",
+    ))
 }
 
 // Helper functions
@@ -170,6 +168,7 @@ fn value_to_string(value: &Value) -> String {
     }
 }
 
+#[cfg(not(feature = "serde-support"))]
 fn value_to_json_simple(value: &Value) -> String {
     match value {
         Value::Null => "null".to_string(),

--- a/src/fs_stream.rs
+++ b/src/fs_stream.rs
@@ -35,8 +35,6 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Global registry of open file streams.
-/// In a real implementation, this would be managed by the SafetyConfig/Registry.
 lazy_static::lazy_static! {
     static ref STREAMS: Arc<Mutex<HashMap<i64, FileStream>>> = Arc::new(Mutex::new(HashMap::new()));
 }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -2,12 +2,12 @@
 //!
 //! Provides access to Kubernetes resources and operations.
 
-use k8s_openapi::api::core::v1::{ConfigMap, Namespace, Pod, Secret, Service};
+use k8s_openapi::api::core::v1::{ConfigMap, Namespace, Pod, Secret};
 use kube::{
-    api::{Api, ListParams, PostParams},
+    api::{Api, ListParams},
     Client, Config,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use crate::error::{Error, Result};
 use fusabi_host::Value;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -134,9 +134,7 @@ impl MetricsRegistry {
         } else {
             drop(histograms);
             let mut histograms = self.histograms.write();
-            let histogram = histograms
-                .entry(name.to_string())
-                .or_insert_with(Histogram::new);
+            let histogram = histograms.entry(name.to_string()).or_default();
             histogram.observe(value);
         }
     }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -2,16 +2,9 @@
 //!
 //! Provides logging, tracing, and metrics integration using OpenTelemetry.
 
-use opentelemetry::{
-    global,
-    trace::{Tracer, TracerProvider},
-    KeyValue,
-};
+use fusabi_host::Value;
 use std::collections::HashMap;
 use std::time::Duration;
-
-use crate::error::{Error, Result};
-use fusabi_host::Value;
 
 /// Configuration for observability features.
 #[derive(Debug, Clone)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use fusabi_host::ExecutionContext;
 use fusabi_host::Value;
 
-use crate::error::{Error, Result};
 use crate::safety::SafetyConfig;
 
 /// Execute a command and wait for completion.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use fusabi_host::HostRegistry;
 
 use crate::config::StdlibConfig;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::safety::SafetyConfig;
 
 /// Registry for stdlib modules.
@@ -136,19 +136,17 @@ impl StdlibRegistry {
     pub fn register_path(&self, registry: &mut HostRegistry) -> Result<()> {
         use crate::path;
 
-        registry.register_module("path", "join", |args, ctx| path::join(args, ctx));
+        registry.register_module("path", "join", path::join);
 
-        registry.register_module("path", "dirname", |args, ctx| path::dirname(args, ctx));
+        registry.register_module("path", "dirname", path::dirname);
 
-        registry.register_module("path", "basename", |args, ctx| path::basename(args, ctx));
+        registry.register_module("path", "basename", path::basename);
 
-        registry.register_module("path", "extension", |args, ctx| path::extension(args, ctx));
+        registry.register_module("path", "extension", path::extension);
 
-        registry.register_module("path", "normalize", |args, ctx| path::normalize(args, ctx));
+        registry.register_module("path", "normalize", path::normalize);
 
-        registry.register_module("path", "is_absolute", |args, ctx| {
-            path::is_absolute(args, ctx)
-        });
+        registry.register_module("path", "is_absolute", path::is_absolute);
 
         Ok(())
     }
@@ -166,7 +164,7 @@ impl StdlibRegistry {
         let s = safety.clone();
         registry.register_module("env", "set", move |args, ctx| env::set(&s, args, ctx));
 
-        registry.register_module("env", "cwd", |args, ctx| env::cwd(args, ctx));
+        registry.register_module("env", "cwd", env::cwd);
 
         Ok(())
     }
@@ -176,19 +174,13 @@ impl StdlibRegistry {
     pub fn register_format(&self, registry: &mut HostRegistry) -> Result<()> {
         use crate::format;
 
-        registry.register_module("format", "sprintf", |args, ctx| format::sprintf(args, ctx));
+        registry.register_module("format", "sprintf", format::sprintf);
 
-        registry.register_module("format", "template", |args, ctx| {
-            format::template(args, ctx)
-        });
+        registry.register_module("format", "template", format::template);
 
-        registry.register_module("format", "json_encode", |args, ctx| {
-            format::json_encode(args, ctx)
-        });
+        registry.register_module("format", "json_encode", format::json_encode);
 
-        registry.register_module("format", "json_decode", |args, ctx| {
-            format::json_decode(args, ctx)
-        });
+        registry.register_module("format", "json_decode", format::json_decode);
 
         Ok(())
     }
@@ -219,17 +211,15 @@ impl StdlibRegistry {
     pub fn register_time(&self, registry: &mut HostRegistry) -> Result<()> {
         use crate::time;
 
-        registry.register_module("time", "now", |args, ctx| time::now(args, ctx));
+        registry.register_module("time", "now", time::now);
 
-        registry.register_module("time", "now_millis", |args, ctx| {
-            time::now_millis(args, ctx)
-        });
+        registry.register_module("time", "now_millis", time::now_millis);
 
-        registry.register_module("time", "sleep", |args, ctx| time::sleep(args, ctx));
+        registry.register_module("time", "sleep", time::sleep);
 
-        registry.register_module("time", "format", |args, ctx| time::format_time(args, ctx));
+        registry.register_module("time", "format", time::format_time);
 
-        registry.register_module("time", "parse", |args, ctx| time::parse_time(args, ctx));
+        registry.register_module("time", "parse", time::parse_time);
 
         Ok(())
     }
@@ -239,17 +229,11 @@ impl StdlibRegistry {
     pub fn register_metrics(&self, registry: &mut HostRegistry) -> Result<()> {
         use crate::metrics;
 
-        registry.register_module("metrics", "counter_inc", |args, ctx| {
-            metrics::counter_inc(args, ctx)
-        });
+        registry.register_module("metrics", "counter_inc", metrics::counter_inc);
 
-        registry.register_module("metrics", "gauge_set", |args, ctx| {
-            metrics::gauge_set(args, ctx)
-        });
+        registry.register_module("metrics", "gauge_set", metrics::gauge_set);
 
-        registry.register_module("metrics", "histogram_observe", |args, ctx| {
-            metrics::histogram_observe(args, ctx)
-        });
+        registry.register_module("metrics", "histogram_observe", metrics::histogram_observe);
 
         Ok(())
     }

--- a/src/terminal_ui.rs
+++ b/src/terminal_ui.rs
@@ -2,14 +2,13 @@
 //!
 //! Provides Ratatui/TUI widgets and helpers for building terminal user interfaces.
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Line, Span, Text},
+    text::Span,
     widgets::{Block, Borders, List, ListItem, Paragraph},
-    Frame, Terminal,
+    Terminal,
 };
 use std::io::Stdout;
 


### PR DESCRIPTION
## Summary
- Add `serde-support` feature to Cargo.toml for JSON encoding/decoding
- Remove unused imports across modules (registry, process, observability, k8s, terminal_ui)
- Replace redundant closures with function references in registry.rs
- Add cfg attributes to `value_to_json_simple` and `json_decode` for conditional compilation
- Use `or_default()` instead of `or_insert_with(Histogram::new)` in metrics.rs
- Remove doc comment on lazy_static macro invocation in fs_stream.rs

## Test plan
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test` passes (35 tests)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)