### PR TITLE
ci: add native aarch64 Linux to CI and release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,26 @@ jobs:
           ! grep -r "](\.\..*MISSING" docs/ || (echo "Found broken links" && exit 1)
           echo "Link check passed!"
 
+  aarch64:
+    name: aarch64 Linux (native)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install native dev deps
+        # libssl-dev + pkg-config cover reqwest's default native-tls backend,
+        # which is pulled in transitively by the `net` / `net_http` features.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (default features)
+        run: cargo check
+      - name: Check (all features)
+        run: cargo check --all-features
+      - name: Test (default features)
+        run: cargo test
+
   msrv:
     name: MSRV (1.75)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,25 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings --cfg docsrs -A unexpected_cfgs -A rustdoc::broken_intra_doc_links
 
+  validate-aarch64:
+    name: Validate on aarch64 Linux
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install native dev deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (all features)
+        run: cargo check --all-features
+      - name: Run tests
+        run: cargo test --all-features
+
   build:
     name: Build Release
-    needs: validate
+    needs: [validate, validate-aarch64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

`raibid-harness` (incoming DGX-Spark-native harness for coding agents)
targets `aarch64-unknown-linux-gnu` as its primary triple.
`fusabi-stdlib-ext` ships the domain packs (process / fs / net /
observability / k8s / gpu / terminal-ui) that `harness-skills` and
`harness-observability` rely on. Today CI runs only on x86_64, so
aarch64 breakage can ship to crates.io unnoticed.

See survey: `/tmp/fusabi-aarch64-survey.md`.

## What changed

**`.github/workflows/ci.yml`**
- New `aarch64` job on `ubuntu-24.04-arm`. Installs `libssl-dev` and
  `pkg-config` (for reqwest's default `native-tls` backend used by
  `net` / `net_http`), then runs `cargo check` (default features),
  `cargo check --all-features`, and `cargo test` (default features).

**`.github/workflows/release.yml`**
- New `validate-aarch64` job that runs `cargo check --all-features` and
  `cargo test --all-features` on `ubuntu-24.04-arm`. Wired into
  `build.needs` so a broken aarch64 build blocks `cargo publish`.

## Feature-by-feature aarch64 risk assessment

| Feature        | Backend                                    | aarch64 risk  |
| -------------- | ------------------------------------------ | ------------- |
| `process`      | tokio                                      | None          |
| `fs` / `path` / `env` / `format` / `time` | std              | None          |
| `net` / `net_http` | `reqwest` default (`native-tls`)      | OpenSSL dev libs required — installed in both new jobs |
| `metrics`      | prometheus (pure Rust)                     | None          |
| `terminal` / `terminal-ui` | crossterm + ratatui            | None          |
| `observability` | opentelemetry (pure Rust)                 | None          |
| `k8s`          | kube + k8s-openapi (pure Rust + tokio)     | None          |
| `gpu`          | **currently a mock** (`src/gpu.rs` returns hardcoded "Mock GPU" values; TODO mentions future NVML) | None today, but needs reassessment when real NVML lands |
| `sigilforge`   | external sigilforge-client                 | Not audited   |

## Test plan

- [ ] New `aarch64 Linux (native)` CI job passes on this PR.
- [ ] Dispatch `Release` with a pre-release tag and confirm
      `validate-aarch64` succeeds before `build` runs.

## Known gaps

- `gpu` feature: flagged above. When NVML wrapper is added, aarch64
  story may need a conditional compile gate or a feature split
  (`gpu-nvml-linux` vs `gpu-mock`). Not in scope for this PR.
- `sigilforge` feature is not audited here; if CI reveals an aarch64
  break, I'll follow up with a targeted fix.

## Status

**Draft** — ready-for-review after a green aarch64 run.