### PR TITLE
ci: green up main — rustdoc + patched-CVE lockfile bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cassowary"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-/// Result type alias using [`Error`].
+/// Result type alias using [`enum@Error`].
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can occur during stdlib operations.


### PR DESCRIPTION
## Summary

Mechanical green-up of main-branch CI. Lockfile-only dep bumps plus one rustdoc fix. No `Cargo.toml` edits, no workflow edits, no MSRV changes.

## Targeted failing CI jobs

- **Docs** (`RUSTDOCFLAGS=-D warnings`) — fixed by disambiguating the intra-doc link on the `Result<T>` type alias in `src/error.rs`. `Error` is both the enum and the `thiserror::Error` derive macro re-export, so we now link explicitly as `[`enum@Error`]`.
- **Security Audit** (partial) — `bytes` bumped 1.11.0 → 1.11.1 via `cargo update -p bytes --precise 1.11.1`, resolving **RUSTSEC-2026-0007**.

## Out of scope (left for follow-up PRs / design calls)

These CVEs cannot be resolved lockfile-only and would need `Cargo.toml` dep surgery, a crate swap, or an MSRV bump — all of which deserve their own PR and review:

- **RUSTSEC-2026-0098 / RUSTSEC-2026-0099** (`rustls-webpki 0.101.7`) — pinned transitively by `rustls 0.21.12` via `kube 0.88` and `reqwest 0.11`. Neither `--precise 0.103.12` nor a plain `cargo update` can reach a patched version without major upstream bumps. Try `cargo update -p rustls-webpki --precise 0.103.12` locally to confirm.
- **RUSTSEC-2026-0002** (`lru 0.12.5` unsound) — pinned by `ratatui 0.26.3` to `^0.12`. Needs a `ratatui` major bump.
- **RUSTSEC-2024-0437** (`protobuf 2.28.0` via `prometheus 0.13.4`) — requires a `prometheus` crate swap or major upstream bump. Design decision.
- **RUSTSEC-2026-0097** (`rand 0.8.5` via `shared_memory 0.12.4`) — `shared_memory` is unmaintained-adjacent. Needs a replacement strategy.
- **Unmaintained-info** on `paste` and `rustls-pemfile` — informational; follow-up only.
- **MSRV (1.75)** — `home 0.5.12` transitively requires edition-2024 (rustc ≥1.85). Bumping MSRV is a public-contract change; deferred.

## Diff footprint

- `Cargo.lock` — `bytes` 1.11.0 → 1.11.1 (checksum only).
- `src/error.rs` — one doc-comment character tweak.

## Local gates

- `cargo fmt --all --check` — clean.
- `RUSTDOCFLAGS=-D warnings cargo doc --all-features --no-deps` — clean.
- `cargo check --all-features` — clean.
- `cargo audit` — not installed locally; skipped. CI will confirm.

## Test plan

- [ ] Docs job passes on CI.
- [ ] Security Audit job passes or drops the 5 CVEs listed out-of-scope (those will still show; see above).
- [ ] MSRV (1.75) job will likely still fail on `home 0.5.12` edition-2024; that is acknowledged out-of-scope.
- [ ] All other jobs remain green.

Autonomously prepared by raibid-harness wave-5. Review before merge; note out-of-scope CVEs still need design decisions.